### PR TITLE
Fix issue with missing gatsby-plugin-styled-components

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,6 +8,7 @@ module.exports = {
     `gatsby-plugin-react-helmet`,
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
+    `gatsby-plugin-styled-components`,
     {
       resolve: "gatsby-plugin-react-svg",
       options: {


### PR DESCRIPTION
I noticed some CSS flickering on the initial page load. It appears that gatsby-plugin-styled-components wasn't added to the gatsby-config file.